### PR TITLE
Remove unused code and testify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/jackc/pgpassfile
 
 go 1.12
-
-require github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,0 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/pgpass.go
+++ b/pgpass.go
@@ -5,7 +5,6 @@ import (
 	"bufio"
 	"io"
 	"os"
-	"regexp"
 	"strings"
 )
 
@@ -48,12 +47,6 @@ func ParsePassfile(r io.Reader) (*Passfile, error) {
 
 	return passfile, scanner.Err()
 }
-
-// Match (not colons or escaped colon or escaped backslash)+. Essentially gives a split on unescaped
-// colon.
-var colonSplitterRegexp = regexp.MustCompile("(([^:]|(\\:)))+")
-
-// var colonSplitterRegexp = regexp.MustCompile("((?:[^:]|(?:\\:)|(?:\\\\))+)")
 
 // parseLine parses a line into an *Entry. It returns nil on comment lines or any other unparsable
 // line.

--- a/pgpass_test.go
+++ b/pgpass_test.go
@@ -2,28 +2,9 @@ package pgpassfile
 
 import (
 	"bytes"
-	"strings"
+	"reflect"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func unescape(s string) string {
-	s = strings.Replace(s, `\:`, `:`, -1)
-	s = strings.Replace(s, `\\`, `\`, -1)
-	return s
-}
-
-var passfile = [][]string{
-	{"test1", "5432", "larrydb", "larry", "whatstheidea"},
-	{"test1", "5432", "moedb", "moe", "imbecile"},
-	{"test1", "5432", "curlydb", "curly", "nyuknyuknyuk"},
-	{"test2", "5432", "*", "shemp", "heymoe"},
-	{"test2", "5432", "*", "*", `test\\ing\:`},
-	{"localhost", "*", "*", "*", "sesam"},
-	{"test3", "*", "", "", "swordfish"}, // user will be filled later
-}
 
 func TestParsePassFile(t *testing.T) {
 	buf := bytes.NewBufferString(`# A comment
@@ -36,17 +17,31 @@ func TestParsePassFile(t *testing.T) {
 		`)
 
 	passfile, err := ParsePassfile(buf)
-	require.Nil(t, err)
+	requireNil(t, err)
 
-	assert.Len(t, passfile.Entries, 6)
+	assertEqual(t, len(passfile.Entries), 6)
 
-	assert.Equal(t, "whatstheidea", passfile.FindPassword("test1", "5432", "larrydb", "larry"))
-	assert.Equal(t, "imbecile", passfile.FindPassword("test1", "5432", "moedb", "moe"))
-	assert.Equal(t, `test\ing:`, passfile.FindPassword("test2", "5432", "something", "else"))
-	assert.Equal(t, "sesam", passfile.FindPassword("localhost", "9999", "foo", "bare"))
+	assertEqual(t, "whatstheidea", passfile.FindPassword("test1", "5432", "larrydb", "larry"))
+	assertEqual(t, "imbecile", passfile.FindPassword("test1", "5432", "moedb", "moe"))
+	assertEqual(t, `test\ing:`, passfile.FindPassword("test2", "5432", "something", "else"))
+	assertEqual(t, "sesam", passfile.FindPassword("localhost", "9999", "foo", "bare"))
 
-	assert.Equal(t, "", passfile.FindPassword("wrong", "5432", "larrydb", "larry"))
-	assert.Equal(t, "", passfile.FindPassword("test1", "wrong", "larrydb", "larry"))
-	assert.Equal(t, "", passfile.FindPassword("test1", "5432", "wrong", "larry"))
-	assert.Equal(t, "", passfile.FindPassword("test1", "5432", "larrydb", "wrong"))
+	assertEqual(t, "", passfile.FindPassword("wrong", "5432", "larrydb", "larry"))
+	assertEqual(t, "", passfile.FindPassword("test1", "wrong", "larrydb", "larry"))
+	assertEqual(t, "", passfile.FindPassword("test1", "5432", "wrong", "larry"))
+	assertEqual(t, "", passfile.FindPassword("test1", "5432", "larrydb", "wrong"))
+}
+
+func assertEqual(t *testing.T, actual, expected interface{}) {
+	t.Helper()
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Expected %#v but got: %#v", expected, actual)
+	}
+}
+
+func requireNil(t *testing.T, object interface{}) {
+	if object != nil {
+		t.Fatalf("Expected nil, but got: %#v", object)
+	}
 }


### PR DESCRIPTION
Hi, I propose dropping testify from this library to reduce the number of testify versions in `pgx/go.sum`.